### PR TITLE
Fix destroy TypeError on popper-content

### DIFF
--- a/src/popper-content.ts
+++ b/src/popper-content.ts
@@ -234,7 +234,9 @@ export class PopperContent implements OnDestroy {
   }
 
   hide(): void {
-    this.popperInstance.destroy();
+    if (this.popperInstance) {
+      this.popperInstance.destroy();
+    }
     this.toggleVisibility(false);
     this.onHidden.emit();
   }


### PR DESCRIPTION
Fixes this error occurring occasionally on leaving element
ERROR TypeError: Cannot read property 'destroy' of undefined
    at PopperContent.hide (vendor.js:68604)
    at PopperContent.showOnLeave (vendor.js:68563)